### PR TITLE
Add paper on skip connections and implicit second-order info

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ We warmly invite anyone interested to join us. To participate:
 
 - Provable Benefits of Local Steps in Heterogeneous **Federated Learning** for Neural Networks: A Feature Learning Perspective, *ICML 2024*, [link](https://proceedings.mlr.press/v235/bao24a.html)
 
+- Understand the Effectiveness of **Shortcuts** through the Lens of DCA, *arXiv 2024*. [(link)](https://arxiv.org/abs/2412.09853)
+
 ## Regression
 
 - Feature Learning in Infinite-Width Neural Networks, *ICML 2021*. [(link)](https://arxiv.org/abs/2011.14522)


### PR DESCRIPTION
Adding a paper to the Classification section:

**Understand the Effectiveness of Shortcuts through the Lens of DCA** (arXiv 2412.09853)

Shows that skip connections implicitly give the optimizer access to Hessian (second-order) information via DCA decomposition. This affects how features are learned: the gradient update in a vanilla network under DCA turns out to match the gradient of a skip-connected network. The paper also introduces NegNet, which replaces the additive shortcut h + F(h) with h = -h + F(h) and still matches ResNet performance.